### PR TITLE
Add localeStrings property, demo and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------------------
 
+## 1.1.0
+- Add `localeStrings` exported prop on wc-i18n-src
+- Add demo of using `localeStrings`
+
 ## 1.0.1
 - Bugfix for Firefox null value bug
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-i18n",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],
@@ -24,6 +24,9 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "Polymer/web-component-tester#master"
+    "web-component-tester": "Polymer/web-component-tester#master",
+    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^1.1.3",
+    "paper-menu": "PolymerElements/paper-menu#^1.2.2",
+    "paper-item": "PolymerElements/paper-item#^1.1.4"
   }
 }

--- a/demo/date-demo/date-demo.html
+++ b/demo/date-demo/date-demo.html
@@ -1,0 +1,49 @@
+<link rel="import" href="../../wc-i18n.html">
+<link rel="import" href="../../../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../../../paper-menu/paper-menu.html">
+<link rel="import" href="../../../paper-item/paper-item.html">
+
+<dom-module id="date-demo">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <wc-i18n-src id='i18n' locale='[[lang]]' locale-dir='[[localeDir()]]' domain='date-demo' locale-strings='{{_i18n}}'></wc-i18n-src>
+    <select id="monthLang" value='{{lang::change}}'>
+      <option value="en">en</option>
+      <option value="ko">ko</option>
+    </select>
+    <paper-dropdown-menu label="Month of the year">
+      <paper-menu class="dropdown-content">
+        <template is='dom-repeat' items='[[_months]]' as='month'>
+          <paper-item>[[month]]</paper-item>
+        </template>
+      </paper-menu>
+    </paper-dropdown-menu>
+  </template>
+  <script>
+    Polymer({
+      is: 'date-demo',
+      properties: {
+        _i18n: {
+          type: Object,
+        },
+        _months: {
+          type: Array,
+          computed: '_computeMonths(_i18n)'
+        }
+      },
+      behaviors: [
+        WCI18nBehavior
+      ],
+      _computeMonths: function(obj) {
+        var localeMonths = obj;
+        return Object.keys(localeMonths).map(function(key) {
+          return localeMonths[key];
+        });
+      }
+    });
+  </script>
+</dom-module>

--- a/demo/date-demo/locales/date-demo_en.json
+++ b/demo/date-demo/locales/date-demo_en.json
@@ -1,0 +1,14 @@
+{
+  "january":"January",
+  "february":"February",
+  "march":"March",
+  "april":"April",
+  "may":"May",
+  "june":"June",
+  "july":"July",
+  "august":"August",
+  "september":"September",
+  "october":"October",
+  "november":"November",
+  "december":"December"
+}

--- a/demo/date-demo/locales/date-demo_ko.json
+++ b/demo/date-demo/locales/date-demo_ko.json
@@ -1,0 +1,14 @@
+{
+  "january":"1월",
+  "february":"2월",
+  "march":"3월",
+  "april":"4월",
+  "may":"5월",
+  "june":"6월",
+  "july":"7월",
+  "august":"8월",
+  "september":"9월",
+  "october":"10월",
+  "november":"11월",
+  "december":"12월"
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,7 @@ Or see the LICENSE file that comes with this code.
     <link rel="import" href="../wc-i18n.html">
     <link rel="import" href="../wc-i18n-src.html">
     <link rel="import" href="./demo-comp/demo-comp.html">
+    <link rel="import" href="./date-demo/date-demo.html">
   </head>
   <body>
     <!-- Provides the 'default' domain in english -->
@@ -70,6 +71,9 @@ Or see the LICENSE file that comes with this code.
 
     <p style="margin-top: 50px;">Using a <strong>&lt;demo-comp&gt;</strong> component</p>
     <demo-comp></demo-comp>
+
+    <p style="margin-top: 50px;">Using a <strong>&lt;date-demo&gt;</strong> component</p>
+    <date-demo></date-demo>
 
     <script>
       var i18nDomain = document.querySelector('#i18nDomain');

--- a/test/wc-i18n-src-test.html
+++ b/test/wc-i18n-src-test.html
@@ -60,6 +60,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               test('`localeDir` defaults to `locales` if not passed', function() {
                 assert.equal(blankEl.localeDir, 'locales');
               });
+              test('`localeStrings` defaults to `null` if not available', function() {
+                assert.equal(blankEl.localeStrings, null);
+              });
               test('`srcLocales` defaults to `null` if not passed', function() {
                 assert.equal(blankEl.srcLocales, null);
               });
@@ -96,6 +99,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 assert.equal(sourcedEl.getKey('hello-msg'), 'Hello!');
                 assert.equal(sourcedEl.getKey('hello-msg', 'ko'), '안녕하세요!');
                 assert.equal(sourcedEl.getKey('hello-msg', 'fr'), 'Bonjour!');
+              });
+              test('`localeStrings` returns available strings', function() {
+                // Flush to allow for data propagation
+                flush(function() {
+                  assert.deepEqual(sourcedEl.localeStrings, {"hello-msg":"Hello!"});
+                });
               });
             });
           });

--- a/wc-i18n-src.html
+++ b/wc-i18n-src.html
@@ -179,6 +179,16 @@ See the docs for more details.
           type: Object,
           value: null,
           observer: '_srcChanged'
+        },
+
+        /**
+         * An object containing the available key value pairs for the current locale
+         * @type {Object}
+         */
+        localeStrings: {
+          type: Object,
+          value: null,
+          notify: true
         }
       },
 
@@ -337,6 +347,7 @@ See the docs for more details.
         this._domains[this.domain].instances.forEach(function(instance) {
           instance.update(locale);
         });
+        this.localeStrings = this.getLocale();
       }
     });
   })();


### PR DESCRIPTION
### Changes

- Add `localeStrings` exported prop on `wc-i18n-src`
- Add demo of using `localeStrings`

