### PR TITLE
Adding a language fallback

### DIFF
--- a/wc-i18n.html
+++ b/wc-i18n.html
@@ -118,6 +118,15 @@ Create your wc-i18n-src element here (see first example)
         value: null,
         readOnly: true,
         notify: true
+      },
+
+      /**
+       * In the event the language requested does not exist, or the string requested
+       * does not exist in the requested language, check for it in this language.
+       */
+      fallback: {
+        type: String,
+        value: null
       }
     },
 
@@ -182,7 +191,12 @@ Create your wc-i18n-src element here (see first example)
      * Get the translation string and replace the content of the element.
      */
     update: function(locale) {
-      var msg = this._domains[this._domain].locales[locale][this._msgid];
+      var locales = this._domains[this._domain].locales;
+      if(!locales[locale] || !locales[locale][this._msgid]) {
+        console.warn('wc-i18n: Language/Key combination not found: ' + locale + ' ' + this._msgid);
+        if(this.fallback) locale = this.fallback;
+      }
+      var msg = locales[locale][this._msgid];
       if (msg) {
         this._setValue(msg);
         if (!this.provider) {

--- a/wc-i18n.html
+++ b/wc-i18n.html
@@ -126,7 +126,7 @@ Create your wc-i18n-src element here (see first example)
        */
       fallback: {
         type: String,
-        value: null
+        value: ''
       }
     },
 
@@ -155,7 +155,7 @@ Create your wc-i18n-src element here (see first example)
       // Register instance to the domain.
       this._domains[this._domain].instances.push(this);
 
-      var locale = this._domains[this._domain].activeLocale || 'en';
+      var locale = this._domains[this._domain].activeLocale || this.fallback || 'en';
 
       // Update the content already here if the locale is already loaded.
       if (this._domains[this._domain].locales[locale] && !this._domains[this._domain].loading) {


### PR DESCRIPTION
This PR makes it so that, in the event the given key doesn't exist in the requested language, the implementer can specify a fallback language in which all keys should always exist. This is particularly useful when users are able to set the language themselves using a language picker--especially if some parts of a site support languages other parts of the site do not.

The fallback is applied on a per-key basis.

I can add unit test(s), but want to know you'll accept this approach before doing so.