### PR TITLE
Replace `navigator.language` with `navigator.languages[0]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 node_modules
+*.iml

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-i18n",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/wc-i18n-src.html
+++ b/wc-i18n-src.html
@@ -55,6 +55,21 @@ See the docs for more details.
     };
 
     /**
+     * Gets the preferred language from the browser.
+     */
+    var getNavigatorLanguage = function() {
+      var navLang = navigator.language;
+
+      /* navigator.languages[0] is better, if it exists, because navigator.language is set
+       * to the OS language in Chrome. */
+      if (navigator.languages && navigator.languages.length > 0) {
+        navLang = navigator.languages[0];
+      }
+
+      return navLang;
+    };
+
+    /**
      * The global cache for all locales loaded.
      */
     window._WCI18n = window._WCI18n || {
@@ -103,7 +118,7 @@ See the docs for more details.
         locale: {
           type: String,
           value: function() {
-            var lang = window.navigator.languages[0];
+            var lang = getNavigatorLanguage();
             if (lang) {
               return lang.match(/(\w{2})/)[1];
             }

--- a/wc-i18n-src.html
+++ b/wc-i18n-src.html
@@ -103,7 +103,7 @@ See the docs for more details.
         locale: {
           type: String,
           value: function() {
-            var lang = window.navigator.language;
+            var lang = window.navigator.languages[0];
             if (lang) {
               return lang.match(/(\w{2})/)[1];
             }


### PR DESCRIPTION
### Changes
This is a Chrome only issue.

- Changed to use `navigator.languages[0]` to get the browser language instead of `navigator.language` because Chrome sets `navigator.language` to the OS language instead of the preferred language set by the user in the browser.