### PR TITLE
Update Deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 node_modules
+analysis.json

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ _Example:_
 window.WCI18n.setLanguage('ko'); //- Sets language to 'ko'
 ```
 
+## Running Docs Locally
+
+1. (Once) Install/Update the [Polymer CLI](https://www.npmjs.com/package/polymer-cli): ```npm i -g polymer-cli```
+
+1. Run `bower i` to load all of the dependencies.
+1. Run `polymer analyze > analysis.json` to set up docs page.
+1. Run `polymer serve -o` to run and view docs page including demo.
+
 ## Bugs/Comments
 
 Please feel free to leave a [github issue](https://github.com/jshcrowthe/wc-i18n/issues) if there is a bug or feedback on how to improve this solution

--- a/bower.json
+++ b/bower.json
@@ -20,13 +20,14 @@
     "/tests/"
   ],
   "dependencies": {
-    "fetch": "^1.0.0",
+    "fetch": "^2.0.3",
     "fetch-mock": "https://unpkg.com/fetch-mock@5.5.0/es5/client-browserified.js",
-    "polymer": "Polymer/polymer#^1.2.0",
-    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0"
+    "polymer": "Polymer/polymer#1 - 2",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^2.0.1"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "Polymer/web-component-tester#4.3.4"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 3",
+    "web-component-tester": "Polymer/web-component-tester#5 - 6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#0.7 - 1"
   }
 }

--- a/test/wc-i18n-default-test.html
+++ b/test/wc-i18n-default-test.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
     <script src="../../fetch/fetch.js"></script>
     <script src="../../fetch-mock/index.js"></script>
-    
+
     <script>
       // This is a nasty global test hack. Super bad but it works
       var srcLocales = {
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
 
     <!-- You can use the document as a place to set up your fixtures. -->
-    <test-fixture id="x-el">
+    <test-fixture id="x-el-fixture">
       <template>
         <x-el-inline></x-el-inline>
       </template>
@@ -57,7 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         describe('WCI18n Global Default', function() {
           var xEl;
           beforeEach(function() {
-            xEl = fixture('x-el');
+            xEl = fixture('x-el-fixture');
           });
           it('Should set the default language to the value of WCI18n.language (if set)', function(done) {
             flush(function() {

--- a/test/wc-i18n-test.html
+++ b/test/wc-i18n-test.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
     <script src="../../fetch/fetch.js"></script>
     <script src="../../fetch-mock/index.js"></script>
-    
+
     <script>
       // This is a nasty global test hack. Super bad but it works
       var srcLocales = {
@@ -44,13 +44,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
 
     <!-- You can use the document as a place to set up your fixtures. -->
-    <test-fixture id="x-el">
+    <test-fixture id="x-el-fixture">
       <template>
         <x-el></x-el>
       </template>
     </test-fixture>
 
-    <test-fixture id="x-el-inline">
+    <test-fixture id="x-el-inline-fixture">
       <template>
         <x-el-inline></x-el-inline>
       </template>
@@ -62,7 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var xEl, xElInline, server;
 
           beforeEach(function() {
-            xElInline = fixture('x-el-inline');
+            xElInline = fixture('x-el-inline-fixture');
           });
 
           /**
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
             describe('if strings inlined', function() {
               beforeEach(function() {
-                xElInline = fixture('x-el-inline');
+                xElInline = fixture('x-el-inline-fixture');
               });
               describe('When initialized', function() {
                 it('should have a translation function that returns strings', function(done) {
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
               var i18nFxn;
               beforeEach(function() {
-                xEl = fixture('x-el');
+                xEl = fixture('x-el-fixture');
                 i18nFxn = xEl.i18n;
               });
 


### PR DESCRIPTION
## Changes
* Allow component to run in hybrid mode for polymer 2 or be installed in polymer 1.
  * This includes webcomponentsjs 0.7 - 1
* Update `fetch` and `promise-polyfill`
* Update `iron-component-page` to `3` which includes a new way to run the docs/demo. I included instructions in the `README`