### PR TITLE
Added check for an empty this.is

### DIFF
--- a/wc-i18n.html
+++ b/wc-i18n.html
@@ -254,7 +254,7 @@
         },
 
         __getComponentName: function() {
-          return (typeof this.is === 'string') ? this.is : this.tagName.toLowerCase();
+          return (typeof this.is === 'string' && this.is !== '') ? this.is : this.tagName.toLowerCase();
         },
 
         /**


### PR DESCRIPTION
Some cases in later versions of Polymer 2 leave the this.is as a blank string.