### PR TITLE
Return undefined in i18n init method to avoid first call to observers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 node_modules
 analysis.json
+.idea/

--- a/test/wc-i18n-test.html
+++ b/test/wc-i18n-test.html
@@ -71,7 +71,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           describe('WCI18n', function() {
             describe('by default', function() {
               it('should have an i18n function', function() {
-                expect(xElInline.i18n).to.be.a('function');
+                expect(xElInline.i18n).to.be.an('undefined');
+                flush(function() {
+                  expect(xElInline.i18n).to.be.a('function');
+                });
               });
               it('should have a language property that defaults to `en`', function() {
                 expect(xElInline.language).to.equal('en');

--- a/wc-i18n.html
+++ b/wc-i18n.html
@@ -243,7 +243,7 @@
           i18n: {
             type: Function,
             value: function() {
-              return function() {};
+              return undefined;
             }
           },
 


### PR DESCRIPTION
One of the common issues run into when using this library is the i18n method being used by components before it is ready.  (e.g. component properties that use i18n function to initialize string values).  The 'wc-i18n-translations-loaded' event provides the ability to wait for the translations to be loaded so that the component knows it's safe to use the method.  However it does require components to have this extra bit of boiler plate code.  

I've found that this extra bit of code can be reduced to just include i18n observer methods that require translations to be loaded if we return undefined in the i18n init method.  Polymer does not call observer methods until a the i18n value is actually set.  This appears to be safe since the library sets the i18n method at the same time the  'wc-i18n-translations-loaded' is fired.
