### PR TITLE
Allow numbers to be used as keys

### DIFF
--- a/wc-i18n.html
+++ b/wc-i18n.html
@@ -347,7 +347,7 @@
               if(string) {
                 Object.keys(formatObject)
                   .forEach(function(key) {
-                    var placeholder = new RegExp('{' + key + '}', 'g');
+                    var placeholder = new RegExp('{\\b' + key + '}', 'g');
                     string = string.replace(placeholder, formatObject[key]);
                   });
               }


### PR DESCRIPTION
When calling `i18n('hello', {0: "World"}`, where the locale file contains `"hello": "Hello {0}"`, fails because the key in the second param is a number.  This change will allow numbers to be used as keys.